### PR TITLE
Fix inspect command case sensitivity

### DIFF
--- a/command.go
+++ b/command.go
@@ -123,10 +123,10 @@ func commandCatch(conf *config, args ...string) error {
 func commandInspect(conf *config, args ...string) error {
 
 	if len(args) != 1 {
-		return errors.New("you must provide a unique location name")
+		return errors.New("you must provide a pokemon name")
 	}
 
-	name := args[0]
+	name := strings.ToLower(args[0])
 	if _, exists := conf.caughtPokemon[name]; !exists {
 		fmt.Println("you have not caught that pokemon")
 		return nil


### PR DESCRIPTION
## Summary
- normalize pokemon names in the `inspect` command
- clarify the error message when no name is supplied

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843bdd869ac832da28af114aba411c6