### PR TITLE
Update FetchPokemonDetails test

### DIFF
--- a/internal/pokeapi/pokeapi_test.go
+++ b/internal/pokeapi/pokeapi_test.go
@@ -256,11 +256,12 @@ func TestFetchPokemonDetails(t *testing.T) {
 		httpClient: http.Client{
 			Timeout: 5 * time.Second,
 		},
-		baseURL: ts.URL,
 	}
+	// Override the baseURL with the test server URL
+	client.baseURL = ts.URL
 
 	// Call the FetchPokemonDetails function
-	resp, err := client.FetchPokemonDetails(ts.URL + "/pokemon/pikachu")
+	resp, err := client.FetchPokemonDetails("pikachu")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}


### PR DESCRIPTION
## Summary
- update FetchPokemonDetails test to use pokemon name
- keep test server assignment of `client.baseURL`

## Testing
- `go test ./internal/...`
- `go test ./...` *(fails: Forbidden to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6843bfb49498832db5c205dc03904938